### PR TITLE
Updated to use ansible modules for pip, file (rm) and git plus tidy

### DIFF
--- a/ansible/roles/daliuge_runtime/tasks/daliuge.yml
+++ b/ansible/roles/daliuge_runtime/tasks/daliuge.yml
@@ -1,17 +1,26 @@
 ---
-- name: Update and/or install pip packages
-  command: pip install -U pip setuptools
+# Update and/or install pip packages
+- pip:
+    name: pip setuptools
+    state: latest
 
-- name: Remove any old copy of DALiuGE
-  command: rm -rf daliuge
+# Remove any old copy of DALiuGE
+- file:
+    path: daliuge
+    state: absent
 
-- name: Clone the DALiuGE git reo
-  command: git clone --branch {{ daliuge_version }} https://github.com/ICRAR/daliuge.git
+# Clone the DALiuGE git reo
+#  command: git clone --branch {{ daliuge_version }} https://github.com/ICRAR/daliuge.git
+- git:
+    repo: https://github.com/ICRAR/daliuge.git
+    dest: daliuge
+    version: "{{daliuge_version}}"
 
-- name: Install DALiuGE
-  command: pip install -U .
-  args:
-      chdir: daliuge/
+# Install DALiuGE
+- pip:
+    name: .
+    chdir: daliuge/
+    state: latest
 
 - name: Apply customised DALiuGE configuration
   template:

--- a/ansible/roles/daliuge_runtime/tasks/runtime.yml
+++ b/ansible/roles/daliuge_runtime/tasks/runtime.yml
@@ -7,5 +7,5 @@
 - name: Ensure selected packages are installed
   yum:
     name: "{{item}}"
-    state: present
-  with_items: "{{daliuge_packages}}"
+    state: installed
+    with_items: "{{daliuge_packages}}"

--- a/ansible/roles/daliuge_runtime/tasks/runtime.yml
+++ b/ansible/roles/daliuge_runtime/tasks/runtime.yml
@@ -8,4 +8,4 @@
   yum:
     name: "{{item}}"
     state: installed
-    with_items: "{{daliuge_packages}}"
+  with_items: "{{daliuge_packages}}"


### PR DESCRIPTION
As suggested in previous pull request the code has been updated to use the pip, file and git (not suggested but found so added) modules instead of running commands directly.

runtime.yml modified for consistency