### PR TITLE
alaska_secrets: switch tabs for spaces

### DIFF
--- a/ansible/roles/alaska_secrets/library/barbi.py
+++ b/ansible/roles/alaska_secrets/library/barbi.py
@@ -37,7 +37,7 @@ def main():
     secret_key = module.params['key']
     secret_list = barbican.secrets.list(name=secret_key)
     if secret_list:
-	retrieved_secret = secret_list[0].payload
+        retrieved_secret = secret_list[0].payload
         module.exit_json(changed=True, secret=retrieved_secret)
 
 


### PR DESCRIPTION
Hi @markgoddard  -
When using Python3.x I received a syntax error based on mixed tabs and spaces.
This maybe an issues for others.

Thanks,
Piers.