### PR TITLE
Added a playbook to test ARL with DALiuGE for TSK-1902

### DIFF
--- a/ansible/daliuge_arl.yml
+++ b/ansible/daliuge_arl.yml
@@ -1,0 +1,15 @@
+---
+# This playbook uses the Ansible OpenStack modules to create a DALiuGE
+# cluster using a number of baremetal compute node instances, and
+# deploys the DALiuGE Delayed test platforms and runs the required
+# test.
+#
+# NOTE: Uses the same config files as daliuge.yml.
+#
+- include: setup.yml
+
+- hosts: cluster_node_mgr
+  remote_user: centos
+  become: yes
+  roles:
+    - role: daliuge_arl

--- a/ansible/roles/daliuge_arl/defaults/main.yml
+++ b/ansible/roles/daliuge_arl/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+VIRTENV_LOC: '/root/dlg-arl'
+VIRTENV_BIN_LOC: '{{VIRTENV_LOC}}/bin'
+ARL_LOC: '{{VIRTENV_LOC}}/arl'
+ARL_REQUIREMENTS_LOC: '{{ARL_LOC}}/requirements.txt'

--- a/ansible/roles/daliuge_arl/tasks/daliuge.yml
+++ b/ansible/roles/daliuge_arl/tasks/daliuge.yml
@@ -1,0 +1,99 @@
+---
+# daliuge_arl/tasks/daliuge.yml
+#
+# NOTE: Defaults are loaded from daliuge_arl/defaults/main.yml
+#
+# Update and/or install pip packages
+- pip:
+    name: pip setuptools
+    state: latest
+
+# Remove any old copy of DALiuGE
+- file:
+    path: "{{ VIRTENV_LOC }}"
+    state: absent
+
+## Setup virtualenv -- COULDN'T GET THIS TO WORK
+##- name: Initiate virtualenv
+#  pip: name=dal_arl_venv
+#       virtualenv=dal_arl_venv
+#       extra_args="-m venv"
+#       virtualenv_command=python36
+#       virtualenv_python=python3.6
+
+# Create a virtualenv
+- name: Manually create the initial virtualenv
+  command: python36 -m venv "{{ VIRTENV_LOC }}"
+
+# Install DALiuGE into the virtualenv
+- pip:
+    name: daliuge
+    virtualenv: "{{ VIRTENV_LOC }}"
+    version: 0.5.1
+
+# Install pytest into the virtualenv
+- pip:
+    name: pytest
+    virtualenv: "{{ VIRTENV_LOC }}"
+
+- name: Manually install git lfs for user
+  command: git lfs install
+
+# Clone the updated ARL version that includes the DALiuGE support test
+- git:
+    repo: https://github.com/rtobar/algorithm-reference-library.git
+    dest: "{{ ARL_LOC }}"
+    version: dlg_delayed
+    force: yes
+
+# Add the lfs stuff otherwise tests will fail
+- name: Manually pull from lfs
+  command: git lfs install
+  args:
+    chdir: "{{ ARL_LOC }}"
+
+# Must install the ARL python requirements into the virtualenv
+- pip:
+    virtualenv: "{{ VIRTENV_LOC }}"
+    requirements: "{{ ARL_REQUIREMENTS_LOC }}"
+
+# Need this specific version of dask othersie ARL fails to run correctly
+- pip:
+    name: dask
+    virtualenv: "{{ VIRTENV_LOC }}"
+    version: 0.18.0
+
+- name: Make sure DALiuGE node manager is not running
+  shell: "{{VIRTENV_BIN_LOC}}/dlg nm -s"
+  args:
+    chdir: "{{ ARL_LOC }}"
+
+- name: Run ARL test using DASK
+  shell: "{{VIRTENV_BIN_LOC}}/pytest tests/test_graphs.py::TestDaskGraphs::test_predict_graph"
+  args:
+    chdir: "{{ ARL_LOC }}"
+  register: DASK
+
+- name: Start the DALiuGE node manger
+  shell: "{{VIRTENV_BIN_LOC}}/dlg nm -d --host 0.0.0.0 --port 8000 -v --no-dlm --dlg-path . --cwd"
+  args:
+    chdir: "{{ ARL_LOC }}"
+
+- name: Run ARL test using DALiuGE
+  shell: "{{VIRTENV_BIN_LOC}}/pytest tests/test_graphs.py::TestDaskGraphs::test_predict_graph"
+  args:
+    chdir: "{{ ARL_LOC }}"
+  environment:
+    ARL_USE_DLG_DELAYED: 1
+  register: DALiuGE
+
+- name: Stop the DALiuGE node manager
+  shell: "{{VIRTENV_BIN_LOC}}/dlg nm -s"
+  args:
+    chdir: "{{ ARL_LOC }}"
+
+- name: Output from test using DASK
+  debug: var=DASK.stdout
+
+- name: Output from test using DALiuGE
+  debug: var=DALiuGE.stdout

--- a/ansible/roles/daliuge_arl/tasks/main.yml
+++ b/ansible/roles/daliuge_arl/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# daliuge_arl/tasks/main.yml
+#
+- include: runtime.yml
+- include: daliuge.yml

--- a/ansible/roles/daliuge_arl/tasks/runtime.yml
+++ b/ansible/roles/daliuge_arl/tasks/runtime.yml
@@ -1,0 +1,17 @@
+---
+# daliuge_arl/tasks/runtime.yml
+- name: Install developments tools envrironment group
+  yum:
+    name: "@Development Tools"
+    state: installed
+
+- name: Ensure selected packages are installed
+  yum:
+    name: python36-devel, git-lfs, http://rpmfind.net/linux/centos/7.5.1804/os/x86_64/Packages/graphviz-2.30.1-21.el7.x86_64.rpm
+    state: installed
+
+- name: Ensure selected packages are installed
+  yum:
+    name: "{{item}}"
+    state: installed
+  with_items: "{{daliuge_packages}}"


### PR DESCRIPTION
Added a playbook that uses the Ansible OpenStack modules to create a DALiuGE cluster using a number of baremetal compute node instances, and deploys the DALiuGE Delayed test platforms and runs the required test. The test output is shown at the end.

Based on ansible/daliuge.yml (except needed to remove user and ceph setup due to errors) and uses the same config files as ansible/daliuge.yml. DALiuGE cluster using a number of baremetal compute node instances, and deploys the DALiuGE Delayed test platforms and runs the required test. The test output is shown at the end.

Based on ansible/daliuge.yml (except needed to remove user and ceph setup due to errors) and uses the same config files as ansible/daliuge.yml.